### PR TITLE
Handle packages file containing comments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup
 
 setup(
     name="unbundle",
-    version="0.1.2",
+    version="0.1.3",
     scripts=["unbundle"]
 )

--- a/unbundle
+++ b/unbundle
@@ -23,8 +23,15 @@ def resolve_includes(bundle_name, bundle_path, bundles=False):
             return set(), False
 
         # find name on its own line
-        if f"\n{bundle_name}\n" in open(packages_f, "r").read():
-            return set([bundle_name]), True
+        with open(packages_f, "r") as pkgdef:
+            for line in pkgdef.readlines():
+                # ignore things after a comment '#'
+                c = line.find('#')
+                if c >= 0:
+                    line = line[:c]
+                line = line.strip()
+                if f"{bundle_name}" == line:
+                    return set([bundle_name]), True
 
         print(f"ERROR: could not find {bundle_name} bundle")
         return set(), False


### PR DESCRIPTION
The packages file should be able to contain comments in the same line
as a package name name (everything after the comment character '#' is
to be ignored). Support this with updated logic to find pundle names.